### PR TITLE
fix react-native crash

### DIFF
--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -27,6 +27,7 @@ function batchCallbacks (fn) {
 // bathes obj.onevent = fn like calls
 function batchMethod (obj, method) {
   const descriptor = Object.getOwnPropertyDescriptor(obj, method)
+  if (!descriptor) return
   const newDescriptor = Object.assign({}, descriptor, {
     set (value) {
       const batched =


### PR DESCRIPTION
The core issue is that WebSocket.prototype is {} in React Native environment. Not a long term fix but at least gets things working again.