### PR TITLE
Add typings for `batch`.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,4 +5,6 @@ declare module 'react-easy-state' {
   function store<Store extends object>(obj?: Store): Store
   // takes class or function component and returns a class HOC
   function view<Comp extends ComponentType<any>>(comp: Comp): Comp
+  // this runs the passed function and delays all re-renders until the function is finished running
+  function batch<T = any>(fn: (...args: any[]) => T, ctx?: any, args?: any[]): T;
 }


### PR DESCRIPTION
The `batch`-API is not included in the typescript-definitions. This pull-request should add it.

The generics are mostly there to allow automatic type inference of the return value, and can be left out when writing:

![image](https://user-images.githubusercontent.com/7847742/49235530-8c899300-f3fa-11e8-86c4-643f68340823.png)

If the compiler can't infer it, it'll default to `any`.